### PR TITLE
Investigate failed js fetch error

### DIFF
--- a/MessageLogger/manifest.json
+++ b/MessageLogger/manifest.json
@@ -6,7 +6,7 @@
     { "name": "Modified by dtester", "id": "591534252307513347" }
   ],
   "version": "1.1.0",
-  "main": "./index.js",
+  "main": "index.js",
   "vendetta": {
     "icon": "trash"
   }

--- a/plugins/no-delete/manifest.json
+++ b/plugins/no-delete/manifest.json
@@ -5,7 +5,8 @@
     { "name": "meqativ (original)", "id": "744276454946242723" },
     { "name": "Modified by dtester", "id": "591534252307513347" }
   ],
-  "main": "./index.js",
+  "version": "1.0.0",
+  "main": "index.js",
   "vendetta": { "icon": "ic_hide_24px" }
 }
 


### PR DESCRIPTION
Fix "Failed to fetch js" error by correcting `main` path and adding missing `version` in `manifest.json`.

The Revenge/Vendetta client's loader expects `main` to be `index.js` (not `./index.js`) and some loaders require a `version` field, which caused the fetch to fail.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3b8a8e9-f1b0-478c-8238-ad8fd45a2bae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3b8a8e9-f1b0-478c-8238-ad8fd45a2bae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

