### PR TITLE
Investigate failed js fetch error

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "NoDelete",
+    "description": "Log deleted and edited messages (including embeds). Adds a channel long-press action: Clear log.",
+    "authors": [
+      { "name": "meqativ (original)", "id": "744276454946242723" },
+      { "name": "Modified by dtester", "id": "591534252307513347" }
+    ],
+    "main": "plugins/no-delete/index.js",
+    "hash": "9cacd24520cbff48da0cf80a6cb2b9f77c3ac4505dcf071981ba255c214af5a8",
+    "vendetta": { "icon": "ic_hide_24px" }
+  }
+]


### PR DESCRIPTION
Create `index.json` at the repo root to resolve "Failed to fetch js" errors.

This file provides a Vendetta-compatible plugin index, allowing the loader to correctly discover and fetch plugins like `NoDelete`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf834828-d8dd-4a14-9df5-3bb89b60d19d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf834828-d8dd-4a14-9df5-3bb89b60d19d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

